### PR TITLE
v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+# New in v0.8.0
+
+## IOM
+
+- Objects for fields of other objects are now created on demand
+  - The JSON encoder and decode helper were therefore no longer needed and removed
+  - Accessing an item of an IOM object returns now the field object instead of the value
+- Fixes for object modification
+  - Fixed wrong handling of some value types
+  - Fixed inconsistancy after modification (using icinga objects like nowhere else)
+  - Fixed iom modification handling of sub-fields (incl. nested dictionaries)
+- Improvements for object modification
+  - Implemented partial modification (e.g. of only one field of a dictionary)
+  - Implemented possibility for multiple modifications at once (for the same field)
+- Moved iom IcingaConfigObjects __setattr__
+  - This is a **backward icompatible change**
+  - See commit 8850fdbe6a9357c41303234c2fbdfa23ba84b85d
+- Improved simple_types.Dictionary
+  - Implemented to handle strings only (because Icinga does that)
+  - Accepting non-string keys (as Icinga also does)
+  - Fixed returning container types
+
+
 # New in v0.7.0
 
 - A CHANGELOG.md, that acts like this is the first version ever, but should keep track of future changes

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ for service in localhost.services:
 ## Notice, that ...
 - ... knowledge of the Icinga2 API is recommended
 - ... Python >=3.6 is required
-- ... as soon as I think it's a bit stable, I will put it on PyPi (for easy pip installation);
+- ... as soon as I think it's more stable, I will put it on PyPi (for easy pip installation);
  and it will get a version number >1.0 as soon as it's really stable. Both things haven't happen yet.
 
 ## How to install
@@ -45,4 +45,4 @@ Clone this repository and install via setup.py, for example like this:
  $ python setup.py install
  ```
 
-Development takes place on the dev branch.
+Development takes place on different branches than the master branch.

--- a/icinga2api_py/__init__.py
+++ b/icinga2api_py/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 __author__ = "Tim Lehner"
 
 from .api import API

--- a/icinga2api_py/__init__.py
+++ b/icinga2api_py/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"
 __author__ = "Tim Lehner"
 
 from .api import API

--- a/icinga2api_py/__init__.py
+++ b/icinga2api_py/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__version__ = "0.7.3"
+__version__ = "0.7.4"
 __author__ = "Tim Lehner"
 
 from .api import API

--- a/icinga2api_py/__init__.py
+++ b/icinga2api_py/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__version__ = "0.7.2"
+__version__ = "0.7.3"
 __author__ = "Tim Lehner"
 
 from .api import API

--- a/icinga2api_py/__init__.py
+++ b/icinga2api_py/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__version__ = "0.7.4"
+__version__ = "0.8.0"
 __author__ = "Tim Lehner"
 
 from .api import API

--- a/icinga2api_py/iom/base.py
+++ b/icinga2api_py/iom/base.py
@@ -26,7 +26,7 @@ class ParentObjectDescription:
 	session reference is copied from the parent object.
 	"""
 
-	def __init__(self, session=None, parent=None, field=None):
+	def __init__(self, session=None, parent: "AbstractIcingaObject" = None, field=None):
 		"""Init the parent object description, also see class docstring.
 
 		:param session: The session the object belongs to, can be None if parent and field is set.
@@ -47,6 +47,11 @@ class ParentObjectDescription:
 		else:
 			# Invalid parameters
 			raise ValueError("Unable to build a parent object description: too few information given with parameters")
+
+	def decouple(self):
+		"""Make sure the parent object descriptions is not coupled to a parent."""
+		self.parent = None
+		self.field = None
 
 	def __eq__(self, other):
 		return \
@@ -74,7 +79,10 @@ class AbstractIcingaObject:
 		return self.DESC["name"]
 
 	def _field_type(self, attr):
-		"""Return type class for a field given by name."""
+		"""Return type class for a field given by name.
+
+		:raises KeyError: If the attr is not a field or its type name is not a valid type.
+		"""
 		typename = self.FIELDS[attr]["type"]
 		# Field types are always singular
 		return self.session.types.type(typename, number=Number.SINGULAR)

--- a/icinga2api_py/iom/complex_types.py
+++ b/icinga2api_py/iom/complex_types.py
@@ -190,21 +190,6 @@ class IcingaConfigObjects(CachedResultSet, IcingaObjects):
 		# else
 		return split
 
-	def __setattr__(self, key, value):
-		"""Modify object value(s) if the attribute name is a field of this object type. Otherwise default behavior."""
-		# TODO propably this method should be for the singular form only...
-		if key and key[0] == '_':
-			# Default behavior for private attributes
-			return super().__setattr__(key, value)
-
-		attrs = self.parse_attrs(key)
-		if len(attrs) > 1 and attrs[1] not in self.FIELDS:
-			# Fallback to default for non-fields
-			return super().__setattr__(key, value)
-
-		# Modify this object
-		self.modify({tuple(attrs): value})
-
 	def _modify_prepare(self, modification) -> typing.Mapping:
 		"""Prepare modification: Unify the modification mapping.
 
@@ -291,3 +276,17 @@ class IcingaConfigObjects(CachedResultSet, IcingaObjects):
 
 class IcingaConfigObject(SingleObjectMixin, IcingaConfigObjects):
 	"""Representation of an Icinga object."""
+
+	def __setattr__(self, key, value):
+		"""Modify object value(s) if the attribute name is a field of this object type. Otherwise default behavior."""
+		if key and key[0] == '_':
+			# Default behavior for private attributes
+			return super().__setattr__(key, value)
+
+		attrs = self.parse_attrs(key)
+		if len(attrs) > 1 and attrs[1] not in self.FIELDS:
+			# Fallback to default for non-fields
+			return super().__setattr__(key, value)
+
+		# Modify this object
+		self.modify({tuple(attrs): value})

--- a/icinga2api_py/iom/simple_types.py
+++ b/icinga2api_py/iom/simple_types.py
@@ -7,7 +7,7 @@ Below the encoder is a JSON decoder helper, that provides a object_pairs_hook me
 """
 
 import datetime
-import collections.abc
+from collections.abc import Sequence, Mapping, MutableMapping
 
 
 from .base import Number, ParentObjectDescription, AbstractIcingaObject
@@ -32,6 +32,9 @@ class NativeValue(AbstractIcingaObject):
 
 	def __str__(self):
 		return str(self._value)
+
+	def __repr__(self):
+		return f"<{self.__class__.__name__}: {repr(self._value)}>"
 
 	def __eq__(self, other):
 		return self.value == other
@@ -85,8 +88,6 @@ class Timestamp(NativeValue):
 			return getattr(self.datetime, item)
 		raise AttributeError(f"No such attribute: {item}")
 
-	# TODO implement timestamp manipulation
-
 	# TODO implement timestamp and float/int comparison
 
 	@classmethod
@@ -103,32 +104,98 @@ class Duration(AbstractIcingaObject):
 	# TODO implement
 
 
-class Array(NativeValue, collections.abc.Sequence):
-	"""Icinga Array attribute type. A sequence here."""
-	# TODO MutableSequence
+class _NativeContainerMixin:
+	"""Base type for containers.
+
+	This is basically a collections of utility functions both Dictionary and Array use.
+	"""
+
+	def _convert_container(self, key, value):
+		"""If value is a container, convert it to an appropriate type (Dictionary or Array)."""
+		# This isinstance checks are fine as long as value is created by the default JSON parser
+		if isinstance(value, list):
+			return Array(value, ParentObjectDescription(parent=self, field=key))
+		elif isinstance(value, Mapping):
+			return Dictionary(value, ParentObjectDescription(parent=self, field=key))
+		return value
+
+	@classmethod
+	def _ensure_mapping_string_keys(cls, mapping: Mapping):
+		"""Recursively ensure that every key of the mapping is a string (because Icinga only knows strings as keys).
+
+		To make things easy, this will actually create a new dictionary.
+		"""
+		ret = dict()
+		for key, value in mapping.items():
+			if isinstance(value, Mapping):
+				ret[str(key)] = cls._ensure_mapping_string_keys(value)
+			elif isinstance(value, Sequence):
+				ret[str(key)] = cls._ensure_sequence_string_keys(value)
+			else:
+				ret[str(key)] = value
+		return ret
+
+	@classmethod
+	def _ensure_sequence_string_keys(cls, sequence: Sequence):
+		"""For every item of the sequence: recursively ensure that all possible dictionaries have string keys."""
+		ret = list()
+		for item in sequence:
+			if isinstance(item, Mapping):
+				ret.append(cls._ensure_mapping_string_keys(item))
+			elif isinstance(item, Sequence):
+				ret.append(cls._ensure_sequence_string_keys(item))
+			else:
+				ret.append(item)
+
+		return ret
+
+
+class Array(NativeValue, _NativeContainerMixin, Sequence):
+	"""Icinga Array type.
+
+	A sequence implementation here. Note that this type is not mutable (because Icinga seems not to support array item
+	modification).
+	"""
 
 	def __init__(self, value, parent_descr):
-		super().__init__(list(value), parent_descr)
+		value = list(value)
+		# Ensure string keys for every possible dict in the sequence
+		value = self._ensure_sequence_string_keys(value)
+		super().__init__(value, parent_descr)
 
 	@classmethod
 	def converter(cls, x):
 		return list(x)
 
 	def __getitem__(self, item):
-		return self._value.__getitem__(item)
+		return self._convert_container(item, self._value.__getitem__(item))
 
 	def __len__(self):
 		return self._value.__len__()
 
+	def __eq__(self, other):
+		# Compare equal to both list and tuple
+		try:
+			return super().__eq__(other) or (list(other) == self.value and not isinstance(other, str))
+		except TypeError:
+			return NotImplemented
 
-class Dictionary(NativeValue, collections.abc.MutableMapping):
-	"""Icinga Dictionary attribute type. Also something like a dictionary here."""
 
-	# TODO implement nested dictionaries
+class Dictionary(NativeValue, _NativeContainerMixin, MutableMapping):
+	"""Icinga Dictionary attribute type.
+
+	This is also implemented as a dictionary here, but with some differences:
+	- None is treated as an empty dict
+	- All keys are (recursively) ensured to be strings, because Icinga only handles string keys
+	- Any modification is propagated to the parent (if there is a parent), so that the parent can propagate to its \
+		parent (and so on), so that the modification is send to Icinga
+	"""
 
 	def __init__(self, value, parent_descr):
 		# Icinga may return (JSON) null (=Python None) for an empty dict (e.g. empty vars)
 		value = value if value is not None else dict()
+		# Ensure all keys are strings
+		value = self._ensure_mapping_string_keys(value)
 		super().__init__(value, parent_descr)
 
 	@classmethod
@@ -140,6 +207,10 @@ class Dictionary(NativeValue, collections.abc.MutableMapping):
 	@staticmethod
 	def parse_attrs(attrs):
 		"""Parse attrs with :meth:`icinga2api_py.results.ResultSet.parse_attrs`."""
+		if not isinstance(attrs, Sequence):
+			# attrs is not a string, not a list and not a tuple...
+			# Icinga itself handles only string keys in dictionaries, so attrs are converted to strings here
+			attrs = str(attrs)
 		return ResultSet.parse_attrs(attrs)
 
 	def __getitem__(self, item):
@@ -148,7 +219,7 @@ class Dictionary(NativeValue, collections.abc.MutableMapping):
 			ret = self._value
 			for item in self.parse_attrs(item):
 				ret = ret[item]
-			return ret
+			return self._convert_container(item, ret)
 		except (KeyError, ValueError):
 			raise KeyError("No such key: {}".format(item))
 
@@ -166,7 +237,12 @@ class Dictionary(NativeValue, collections.abc.MutableMapping):
 			attrs = self.parse_attrs(key)
 			for subkey in attrs[:-1]:
 				temp = temp.setdefault(subkey, dict())
-			temp[attrs[-1]] = value
+
+			if isinstance(value, Mapping):
+				# Make sure all keys are strings to handle things like Icinga does
+				temp[attrs[-1]] = self._ensure_mapping_string_keys(value)
+			else:
+				temp[attrs[-1]] = value
 
 	def __setitem__(self, item, value):
 		"""Set a value of a specific item."""
@@ -174,7 +250,7 @@ class Dictionary(NativeValue, collections.abc.MutableMapping):
 
 	def __delitem__(self, item):
 		"""Delete an item."""
-		raise NoUserModify("Deleting an item is not supported (yet)")  # TODO implement
+		raise NoUserModify("Deleting an item is not supported (yet)")
 
 	def __len__(self):
 		return self._value.__len__()

--- a/icinga2api_py/results.py
+++ b/icinga2api_py/results.py
@@ -487,19 +487,30 @@ class SingleResultMixin:
 			# Behave like an empty dict, e.g. when keys() is called
 			return dict()
 
+	@staticmethod
+	def attr_value(attrs, obj):
+		"""Get the attr value of an object.
+
+		:param attrs: Sequence of items to access recursively
+		:param obj: The Mapping object from where to access the attr values
+		:return: obj[attrs[0]][attrs[1]]...[attrs[len(attrs)-1]]
+		:raises: KeyError if further mapping access was not possible.
+		"""
+		item = attrs
+		try:
+			for item in attrs:
+				obj = obj[item]
+			return obj
+		except (KeyError, ValueError):
+			raise KeyError(f"No such key: {item}")
+
 	def __getitem__(self: SingleResultMixinType, item):
 		"""Implements Mapping and sequence access in one."""
 		if isinstance(item, int) or isinstance(item, slice):
 			return self.result(item)
 
-		# Mapping access
-		try:
-			ret = self._raw
-			for item in self.parse_attrs(item):
-				ret = ret[item]
-			return ret
-		except (KeyError, ValueError):
-			raise KeyError("No such key: {}".format(item))
+		# Mapping access: Get attr of raw result
+		return self.attr_value(self.parse_attrs(item), self._raw)
 
 	def __contains__(self: SingleResultMixinType, item):
 		"""Whether there is a value for the given key, or the value is in the results list."""

--- a/tests/icinga_mock/icinga_mock.py
+++ b/tests/icinga_mock/icinga_mock.py
@@ -182,6 +182,10 @@ class Icinga:
 				obj = obj["attrs"]
 				for key, value in parameters["attrs"].items():
 					o = obj
+					# Special case for vars, because they can be None
+					if key[0] == "vars" and o["vars"] is None:
+						o["vars"] = dict()
+
 					for attr in key[:-1]:
 						o = o[attr]
 					o[key[-1]] = value

--- a/tests/icinga_mock/icinga_mock.py
+++ b/tests/icinga_mock/icinga_mock.py
@@ -147,6 +147,12 @@ class Icinga:
 
 		# Parse attrs
 		parameters["attrs"] = parse_attrs(parameters.get("attrs", dict()))
+		# Translate <otype>.attr to attrs.attr
+		d = dict(parameters["attrs"])
+		for key, value in d.items():
+			if f"{key[0]}s" == otype.lower():
+				del parameters["attrs"][key]
+				parameters["attrs"][key[1:]] = value
 
 		if method == "PUT":
 			# Create object with parameters["attrs"] dict

--- a/tests/iom/test_complex_types.py
+++ b/tests/iom/test_complex_types.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the iom.simple_types module.
+"""
+
+import pytest
+
+from icinga2api_py.iom.base import AbstractIcingaObject, Number, ParentObjectDescription
+from icinga2api_py.iom.complex_types import IcingaObjects, IcingaObject, IcingaConfigObject
+from icinga2api_py.iom.complex_types import IcingaConfigObjects as RealIcingaConfigObjects
+from icinga2api_py.models import APIRequest
+
+
+# TODO basic init tests with the different objects (test whether they behave like there parents)
+
+
+@pytest.fixture(scope="module")
+def results():
+	"""Fixture providing example results."""
+	return [{"a": 1, "b": 2}, {"b": 1}]
+
+
+@pytest.fixture(scope="module")
+def icingaobjects(results):
+	"""Fixture providing an IcingaObjects object."""
+	return IcingaObjects(results, parent_descr=ParentObjectDescription("session"))
+
+
+@pytest.mark.parametrize("index, raises, type_", (
+		(0, False, IcingaObject),
+		(-1, False, IcingaObject),
+		(slice(0, -1), False, IcingaObjects),
+		(4, True, IndexError),
+))
+def test_icingaobjects_result(icingaobjects, index, raises, type_):
+	"""Test IcingaObjects.result()."""
+	if raises:
+		with pytest.raises(type_):
+			_ = icingaobjects.result(index)
+	else:
+		obj = icingaobjects.result(index)
+		assert isinstance(obj, type_)
+
+
+def test_icingaobjects_convert(results):
+	"""Test IcingaObjects.convert()."""
+	pod = ParentObjectDescription("session")
+
+	class IcingaObjectsChild(IcingaObjects):
+		pass
+
+	res = IcingaObjectsChild.convert(results, pod)
+	assert isinstance(res, IcingaObjectsChild)
+	assert list(res.results) == results
+	assert res.parent_descr == pod
+
+	# Test fail
+	with pytest.raises(TypeError):
+		_ = IcingaObjectsChild.convert(3, None)
+
+
+@pytest.fixture
+def request_mock(results):
+	"""An APIRequest returning the results on send."""
+	# TODO better mock...
+	req = APIRequest(None, json={
+		"joins": ["jointype"]
+	})
+
+	class Response:
+		def results(self):
+			return results
+
+	def send(*args, **kwargs):
+		return Response()
+
+	req.send = send
+	return req
+
+
+class IcingaConfigObjects(RealIcingaConfigObjects):
+	DESC = {
+		"name": "Objecttype",
+	}
+
+
+@pytest.fixture
+def icingaconfigobjects(request_mock):
+	"""Fixture for an IcingaConfigObject."""
+	return IcingaConfigObjects(request=request_mock)
+
+
+@pytest.mark.parametrize("input, output", (
+		("name", ["name"]),
+		("state", ["attrs", "state"]),
+		(["state"], ["attrs", "state"]),
+		("last_check_result.output", ["attrs", "last_check_result", "output"]),
+		("objecttype.name", ["attrs", "name"]),
+		("jointype.name", ["joins", "jointype", "name"])
+
+))
+def test_icingaconfigobject_parse_attrs(icingaconfigobjects, input, output):
+	"""Test IcingaConfigObject.parse_attrs()."""
+	res = icingaconfigobjects.parse_attrs(input)
+	assert res == output
+
+
+# Modify is tested with iom_e2e

--- a/tests/iom/test_iom_e2e.py
+++ b/tests/iom/test_iom_e2e.py
@@ -133,7 +133,7 @@ def test_modify3(session):
 	assert obj.vars.val2 == val2
 
 
-def test_modify_nested(session):
+def test_modify_nested_dicts(session):
 	"""Test modification of nested dictionary."""
 	obj = session.objects.hosts.localhost.get()
 	# Test two different ways, just to check that both succeed
@@ -152,6 +152,20 @@ def test_modify_nested(session):
 	obj = session.objects.hosts.localhost.get()
 	assert obj.vars.nested.one == {"1": 0}
 	assert obj.vars.nested.two == {"2": 3, "0": 0}
+
+
+def test_modify_nested_objects(session):
+	"""Test modification of nested object."""
+	obj = session.objects.hosts.localhost.get()
+	# Negate current value
+	value = not obj.last_check_result.active
+	check_result = obj.last_check_result
+	check_result.active = value
+	assert obj.last_check_result.active == value
+
+	# Query again to make sure it was flushed
+	obj = session.objects.hosts.localhost.get()
+	assert obj.last_check_result.active == value
 
 
 # TODO improve the existing tests and add more

--- a/tests/iom/test_iom_e2e.py
+++ b/tests/iom/test_iom_e2e.py
@@ -133,4 +133,25 @@ def test_modify3(session):
 	assert obj.vars.val2 == val2
 
 
+def test_modify_nested(session):
+	"""Test modification of nested dictionary."""
+	obj = session.objects.hosts.localhost.get()
+	# Test two different ways, just to check that both succeed
+	obj.vars.nested = {"one": {1: 2}}
+	obj.vars.nested.two = {2: 3}
+
+	# Modify one value
+	obj.vars.nested.one[1] = 0
+	assert obj.vars.nested.one == {"1": 0}  # String "1" because Icinga handles all keys as strings
+
+	# Add value to dict
+	obj.vars.nested.two[0] = 0
+	assert obj.vars.nested.two == {"2": 3, "0": 0}
+
+	# Check that modifications were flushed
+	obj = session.objects.hosts.localhost.get()
+	assert obj.vars.nested.one == {"1": 0}
+	assert obj.vars.nested.two == {"2": 3, "0": 0}
+
+
 # TODO improve the existing tests and add more

--- a/tests/iom/test_simple_types.py
+++ b/tests/iom/test_simple_types.py
@@ -43,7 +43,7 @@ DEFAULT_POD = ParentObjectDescription(0)
 		("Boolean", True),
 		("Timestamp", 1),  # Timestamp doesn't work with datetime as init arg
 		("Array", [1, 2, 3]),
-		("Dictionary", {1: 2, 2: 3}),
+		("Dictionary", {"a": 1, "b": 2}),
 ))
 def test_basics(types, cls_name, value):
 	"""Test the basics for every simple_types type."""
@@ -96,4 +96,13 @@ def test_dictionary():
 	assert tuple(dictionary.values()) == tuple(value.values())
 	assert tuple(dictionary.items()) == tuple(value.items())
 
-	# TODO test modification
+
+@pytest.mark.parametrize("cls, value, res", (
+		(Dictionary, {1: {2: 3}}, {"1": {"2": 3}}),
+		(Dictionary, {1: [{2: 3}]}, {"1": [{"2": 3}]}),
+		(Array, [0, {1: [{2: 3}]}], [0, {"1": [{"2": 3}]}])
+))
+def test_nested(cls, value, res):
+	"""Test nested Dictionary / Array objects, especially their key conversion to strings."""
+	obj = cls(value, DEFAULT_POD)
+	assert obj == res


### PR DESCRIPTION
This merges fixes and improvements regarding the IOM part of this library:
- Objects for fields of other objects are now created on demand
  - The JSON encoder and decode helper were therefore no longer needed and removed
  - Accessing an item of an IOM object returns now the field object instead of the value
- Fixes for object modification
  - Fixed wrong handling of some value types
  - Fixed inconsistancy after modification (using icinga objects like nowhere else)
  - Fixed iom modification handling of sub-fields (incl. nested dictionaries)
- Improvements for object modification
  - Implemented partial modification (e.g. of only one field of a dictionary)
  - Implemented possibility for multiple modifications at once (for the same field)
- Moved iom IcingaConfigObjects ´__setattr__´
  - This is a **backward icompatible change**
  - See commit 8850fdbe6a9357c41303234c2fbdfa23ba84b85d
- Improved simple_types.Dictionary
  - Implemented to handle strings only (because Icinga does that)
  - Accepting non-string keys (as Icinga also does)
  - Fixed returning container types